### PR TITLE
Zwracanie modelu zamiast stringów

### DIFF
--- a/NBPCurrencyAPILib/Models/ExchangeRatesSeries.cs
+++ b/NBPCurrencyAPILib/Models/ExchangeRatesSeries.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NBPAPI.NET.Core.Models
+{
+    public class ExchangeRatesSeries
+    {
+        public string Table { get; set; }
+        public string Currency { get; set; }
+        public string Code { get; set; }
+        public IEnumerable<Rate> Rates { get; set; }
+    }
+}

--- a/NBPCurrencyAPILib/Models/ExchangeRatesSeries.cs
+++ b/NBPCurrencyAPILib/Models/ExchangeRatesSeries.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace NBPAPI.NET.Core.Models
 {

--- a/NBPCurrencyAPILib/Models/Rate.cs
+++ b/NBPCurrencyAPILib/Models/Rate.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NBPAPI.NET.Core.Models
+{
+    public class Rate
+    {
+        public string Currency { get; set; }
+        public string No { get; set; }
+        public DateTime EffectiveDate { get; set; }
+        public decimal Mid { get; set; }
+        public decimal Bid { get; set; }
+        public decimal Ask { get; set; }
+    }
+}

--- a/NBPCurrencyAPILib/Models/Rate.cs
+++ b/NBPCurrencyAPILib/Models/Rate.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NBPAPI.NET.Core.Models
 {

--- a/NBPCurrencyAPILib/NBPAPI_Currency.cs
+++ b/NBPCurrencyAPILib/NBPAPI_Currency.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using NBPAPI.NET.Core.Models;
+using System;
 using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
 
 namespace NBPCurrencyAPILib
 {
@@ -168,9 +167,8 @@ namespace NBPCurrencyAPILib
         /// <param name="currencyCode">ISO 4217 Currency Code.</param>
         /// <param name="startDate">Start date.</param>
         /// <param name="endDate">End date.</param>
-        /// <param name="isJSON"><c>true</c> if returned string will be JSON, <c>false</c> if XML.</param>
         /// <returns>Async XML/JSON result from NBP API.</returns>
-        public static Task<string> GetCurrenciesAsync(char tableCode, string currencyCode, DateTime startDate, DateTime endDate, bool isJSON = true)
+        public static async Task<ExchangeRatesSeries> GetCurrenciesAsync(char tableCode, string currencyCode, DateTime startDate, DateTime endDate)
         {
             currencyCode = currencyCode.ToUpper();
             if (currencyCode.Length != 3) throw new ArgumentException("Code must be 3 letters long, check ISO 4217.");
@@ -179,26 +177,26 @@ namespace NBPCurrencyAPILib
 
             if (!TableLetterCheck(tableLetter[0])) throw new ArgumentException("Incorrect table letter!");
 
-            string getpath = uri + $"exchangerates/rates/{tableLetter}/{currencyCode}/{startDate:yyyy-MM-dd}/{endDate:yyyy-MM-dd}?format={(isJSON ? "json" : "xml")}";
+            string getpath = uri + $"exchangerates/rates/{tableLetter}/{currencyCode}/{startDate:yyyy-MM-dd}/{endDate:yyyy-MM-dd}?format=json";
 
-            HttpResponseMessage result = httpClient.GetAsync(getpath).Result;
+            HttpResponseMessage result = await httpClient.GetAsync(getpath);
 
             if (!result.IsSuccessStatusCode) throw Error(result);
 
-            return result.Content.ReadAsStringAsync();
+            JsonSerializerOptions jsonOptions = new() { PropertyNameCaseInsensitive = true };
+            return JsonSerializer.Deserialize<ExchangeRatesSeries>(await result.Content.ReadAsStringAsync(), jsonOptions);
         }
         /// <summary>
         /// Gets exchange rates from PLN to <paramref name="currencyCode"/> from <paramref name="startDate"/> to <paramref name="endDate"/>.
         /// </summary>
         /// <param name="tableCode">Table Code (Capital A-C).</param>
         /// <param name="currencyCode">ISO 4217 Currency Code.</param>
-        /// <param name="isJSON"><c>true</c> if returned string will be JSON, <c>false</c> if XML.</param>
         /// <param name="endDate">The end date.</param>
         /// <param name="startDate">The start date.</param>
         /// <returns>XML/JSON result from NBP API.</returns>
-        public static string GetCurrencies(char tableCode, string currencyCode, DateTime startDate, DateTime endDate, bool isJSON = true)
+        public static ExchangeRatesSeries GetCurrencies(char tableCode, string currencyCode, DateTime startDate, DateTime endDate)
         {
-            return GetCurrencies(tableCode, currencyCode, startDate, endDate, isJSON);
+            return GetCurrenciesAsync(tableCode, currencyCode, startDate, endDate).Result;
         }
         #endregion GetCurrencies
     }

--- a/NBPCurrencyAPILib/NBPCurrencyAPILib.csproj
+++ b/NBPCurrencyAPILib/NBPCurrencyAPILib.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>C:\Users\Michal\source\repos\NBPCurrencyAPILib\NBPCurrencyAPILib\NBPCurrencyAPILib.xml</DocumentationFile>
+    <DocumentationFile></DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NBPCurrencyAPILibTests/NBPAPICurrencyTests.cs
+++ b/NBPCurrencyAPILibTests/NBPAPICurrencyTests.cs
@@ -38,7 +38,7 @@ namespace NBPCurrencyAPILib.Tests
         [TestMethod()]
         public void GetCurrenciesAsyncTestFromTo()
         {
-            Assert.IsTrue(NBPAPI.GetCurrenciesAsync('A', "EUR", new DateTime(2021, 07, 21), new DateTime(2021, 07, 25)).Result.Contains("code"));
+            Assert.IsTrue(NBPAPI.GetCurrenciesAsync('A', "EUR", new DateTime(2021, 07, 21), new DateTime(2021, 07, 25)).Result.Currency.Any());
         }
 
     }

--- a/NBPCurrencyAPILibTests/NBPAPICurrencyTests.cs
+++ b/NBPCurrencyAPILibTests/NBPAPICurrencyTests.cs
@@ -1,10 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NBPCurrencyAPILib;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NBPCurrencyAPILib.Tests
 {
@@ -32,7 +28,7 @@ namespace NBPCurrencyAPILib.Tests
         [TestMethod()]
         public void GetCurrenciesAsyncTest()
         {
-            Assert.IsTrue(NBPAPI.GetCurrenciesAsync('A', "EUR", 3).Result.Contains("code"));
+            Assert.IsTrue(NBPAPI.GetCurrenciesAsync('A', "EUR", 3).Result.Currency.Any());
         }
 
         [TestMethod()]


### PR DESCRIPTION
Cześć, na potrzeby swojego projektu wprowadziłem małe zmiany do projektu:
* Metody zwracają modele a nie stringi (breaking changes) - Myślę że będzie to mega przydatne, bardziej niż parsowanie/deserializacja stringów
  * Niestety nie byłem w stanie całego zakresu zmienić, ograniczyłem się do metod które wykorzystuje. Daj znać czy dasz radę dorobić resztę
* Poprawiłem asynci - były z nimi problemy
* Dostosowanie testów